### PR TITLE
Se indica un nuevo tipo de error común.

### DIFF
--- a/bugs/errorestipicos.py
+++ b/bugs/errorestipicos.py
@@ -2,3 +2,8 @@
 file = open('./Carta.txt', 'r+')
 file.read() # Lee el archivo
 file.close() # cierra el archivo
+
+# Error tipico, los elementos de un strin son inmutables
+nombre = input('Ingrese su nombre: ')
+nombre[0] = 'e'
+print(nombre)

--- a/bugs/errorestipicos.py
+++ b/bugs/errorestipicos.py
@@ -1,9 +1,10 @@
 # El error tipico al abrir un archivo sin el with es no cerrarlo
-file = open('./Carta.txt', 'r+')
-file.read() # Lee el archivo
-file.close() # cierra el archivo
+#file = open('./Carta.txt', 'r+')
+#file.read() # Lee el archivo
+#file.close() # cierra el archivo
 
 # Error tipico, los elementos de un strin son inmutables
-nombre = input('Ingrese su nombre: ')
+nombre = list(input('Ingrese su nombre: '))
 nombre[0] = 'e'
+nombre = "".join(i for i in nombre)
 print(nombre)


### PR DESCRIPTION
NO se puede renombrar un elemento de un string aunque se acceda a dicho elemento por medio de su indice